### PR TITLE
Add 'message/x.rsocket.application+json'

### DIFF
--- a/src/main/java/am/ik/rsocket/SetupMetadataMimeType.java
+++ b/src/main/java/am/ik/rsocket/SetupMetadataMimeType.java
@@ -39,7 +39,8 @@ enum SetupMetadataMimeType {
 		public ByteBuf encode(String metadata) {
 			return BasicAuthentication.valueOf(metadata).toMetadata(new PooledByteBufAllocator(true));
 		}
-	};
+	},
+	APP_INFO(MimeType.custom("message/x.rsocket.application+json"));
 
 	private final MimeType mimeType;
 


### PR DESCRIPTION
When a RSocket client wants to connect the RSocket Service provider,  almost the client should supply access token(username/password, JWT token etc) and app info, such as app name, UUID,  listen port,  management port and other metadata information, almost alike app registration to Spring Boot Admin.   APP_INFO(MimeType.custom("message/x.rsocket.application+json")) is a metadata in setup composite metadata to send the app info from client to service provider.