### PR TITLE
Adds option for writing response data to output file

### DIFF
--- a/src/main/java/am/ik/rsocket/Args.java
+++ b/src/main/java/am/ik/rsocket/Args.java
@@ -21,6 +21,8 @@ import java.io.PrintStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -195,6 +197,10 @@ public class Args {
 			.acceptsAll(Arrays.asList("optsFile"), "Configure options from a YAML file (e.g. ./opts.yaml, /tmp/opts.yaml, https://example.com/opts.yaml)").withOptionalArg();
 
 	private final OptionSpec<Void> dumpOpts = parser.acceptsAll(Arrays.asList("dumpOpts"), "Dump options as a file that can be loaded by --optsFile option");
+
+	private final OptionSpec<String> outputFile = parser
+			.acceptsAll(Arrays.asList("o", "output"), "Write output to file specified")
+			.withOptionalArg();
 
 	private OptionSet options;
 
@@ -793,6 +799,11 @@ public class Args {
 
 	public boolean isDumpOpts() {
 		return this.options.has(this.dumpOpts);
+	}
+
+	public Optional<Path> outputFile() {
+		return Optional.ofNullable(this.options.valueOf(this.outputFile))
+				.map(Paths::get);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/am/ik/rsocket/InteractionModel.java
+++ b/src/main/java/am/ik/rsocket/InteractionModel.java
@@ -15,8 +15,7 @@
  */
 package am.ik.rsocket;
 
-import java.util.Scanner;
-
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.rsocket.Payload;
 import io.rsocket.RSocket;
@@ -26,6 +25,11 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Scanner;
+import java.util.function.Consumer;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public enum InteractionModel {
@@ -33,33 +37,45 @@ public enum InteractionModel {
 		@Override
 		Publisher<?> request(RSocket rsocket, Args args) {
 			final Mono<Payload> payload = payloadMono(args);
-			return payload.flatMap(p -> rsocket.requestResponse(p).map(Payload::getDataUtf8) //
-					.transform(s -> args.log().map(s::log).orElse(s))
-					.transform(s -> args.quiet() ? s : s.doOnNext(System.out::println)));
+			return removeOutputFileMono(args)
+					.then(payload.flatMap(p -> rsocket.requestResponse(p)
+							// Write the raw response bytes to the indicated output file
+							.doOnNext(writeToOutput(args))
+							.map(Payload::getDataUtf8)
+							.transform(s -> args.log().map(s::log).orElse(s))
+							.transform(s -> args.quiet() ? s : s.doOnNext(System.out::println))));
 		}
 	},
 	REQUEST_STREAM {
 		@Override
 		Publisher<?> request(RSocket rsocket, Args args) {
 			final Mono<Payload> payload = payloadMono(args);
-			return payload.flatMapMany(p -> rsocket.requestStream(p).map(Payload::getDataUtf8)
-					.transform(s -> args.log().map(s::log).orElse(s))
-					.transform(s -> args.limitRate().map(s::limitRate).orElse(s))
-					.transform(s -> args.take().map(s::take).orElse(s))
-					.transform(s -> args.delayElements().map(s::delayElements).orElse(s))
-					.transform(s -> args.quiet() ? s : s.doOnNext(System.out::println)));
+			return removeOutputFileMono(args)
+					.thenMany(payload.flatMapMany(p -> rsocket.requestStream(p)
+							// Write the raw response bytes to the indicated output file
+							.doOnNext(writeToOutput(args))
+							.map(Payload::getDataUtf8)
+							.transform(s -> args.log().map(s::log).orElse(s))
+							.transform(s -> args.limitRate().map(s::limitRate).orElse(s))
+							.transform(s -> args.take().map(s::take).orElse(s))
+							.transform(s -> args.delayElements().map(s::delayElements).orElse(s))
+							.transform(s -> args.quiet() ? s : s.doOnNext(System.out::println))));
 		}
 	},
 	REQUEST_CHANNEL {
 		@Override
 		Publisher<?> request(RSocket rsocket, Args args) {
 			final Flux<Payload> payloads = payloadFlux(args);
-			return rsocket.requestChannel(payloads).map(Payload::getDataUtf8)
-					.transform(s -> args.log().map(s::log).orElse(s))
-					.transform(s -> args.limitRate().map(s::limitRate).orElse(s))
-					.transform(s -> args.take().map(s::take).orElse(s))
-					.transform(s -> args.delayElements().map(s::delayElements).orElse(s))
-					.transform(s -> args.quiet() ? s : s.doOnNext(System.out::println));
+			return removeOutputFileMono(args)
+					.thenMany(rsocket.requestChannel(payloads)
+							// Write the raw response bytes to the indicated output file
+							.doOnNext(writeToOutput(args))
+							.map(Payload::getDataUtf8)
+							.transform(s -> args.log().map(s::log).orElse(s))
+							.transform(s -> args.limitRate().map(s::limitRate).orElse(s))
+							.transform(s -> args.take().map(s::take).orElse(s))
+							.transform(s -> args.delayElements().map(s::delayElements).orElse(s))
+							.transform(s -> args.quiet() ? s : s.doOnNext(System.out::println)));
 		}
 	},
 	FIRE_AND_FORGET {
@@ -69,6 +85,19 @@ public enum InteractionModel {
 			return payload.flatMap(p -> rsocket.fireAndForget(p).transform(s -> args.log().map(s::log).orElse(s)));
 		}
 	};
+
+	private static Consumer<Payload> writeToOutput(Args args) {
+		return (payload) -> args.outputFile().map(path -> {
+			ByteBuf buf = payload.data();
+			byte[] bytes = new byte[buf.readableBytes()];
+			buf.getBytes(buf.readerIndex(), bytes);
+			try {
+				return Files.write(path, bytes);
+			} catch (IOException e) {
+				throw new RuntimeException(e);
+			}
+		});
+	}
 
 	abstract Publisher<?> request(RSocket rsocket, Args args);
 
@@ -112,5 +141,17 @@ public enum InteractionModel {
 		return scanToFlux(scanner) //
 				.collectList() //
 				.map(list -> String.join(System.lineSeparator(), list));
+	}
+
+	static Mono<Void> removeOutputFileMono(Args args) {
+		return Mono.fromRunnable(() -> args.outputFile()
+				.map(path -> {
+					try {
+						Files.deleteIfExists(path);
+						return path;
+					} catch (IOException e) {
+						throw new RuntimeException(e);
+					}
+				}));
 	}
 }

--- a/src/test/java/am/ik/rsocket/ArgsTest.java
+++ b/src/test/java/am/ik/rsocket/ArgsTest.java
@@ -15,6 +15,8 @@
  */
 package am.ik.rsocket;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
@@ -397,5 +399,21 @@ class ArgsTest {
 		final Optional<Flags> trace = args.trace();
 		assertThat(trace.isPresent()).isTrue();
 		assertThat(trace.get()).isEqualTo(Flags.SAMPLE);
+	}
+
+	@Test
+	void output_fullArgument() {
+		final Args args = new Args(new String[] { "tcp://localhost:8080", "--output", "/tmp/some_file" });
+		final Optional<Path> path = args.outputFile();
+		assertThat(path.isPresent()).isTrue();
+		assertThat(path.get()).isEqualTo(Paths.get("/tmp/some_file"));
+	}
+
+	@Test
+	void output_shortArgument() {
+		final Args args = new Args(new String[] { "tcp://localhost:8080", "-o", "/tmp/some_file" });
+		final Optional<Path> path = args.outputFile();
+		assertThat(path.isPresent()).isTrue();
+		assertThat(path.get()).isEqualTo(Paths.get("/tmp/some_file"));
 	}
 }


### PR DESCRIPTION
Adds an argument (-o, --output) which writes the response payload bytes into the indicated file.

I needed to deal with an rsocket server which consumes and produces bytes, rather than a UTF8 Strings, which required reading and writing to files. Loading from a file was already supported so I added this option for writing as well.